### PR TITLE
[PR] Use `register_rest_field()` vs now deprecated `register_api_field`

### DIFF
--- a/wsuwp-extended-events-calendar.php
+++ b/wsuwp-extended-events-calendar.php
@@ -89,11 +89,11 @@ class WSU_Extended_Events_Calendar {
 			'update_callback' => 'esc_html',
 			'schema' => null,
 		);
-		register_api_field( 'tribe_events', 'event_city', $args );
-		register_api_field( 'tribe_events', 'event_state', $args );
-		register_api_field( 'tribe_events', 'event_venue', $args );
-		register_api_field( 'tribe_events', 'start_date', $args );
-		register_api_field( 'tribe_events', 'end_date', $args );
+		register_rest_field( 'tribe_events', 'event_city', $args );
+		register_rest_field( 'tribe_events', 'event_state', $args );
+		register_rest_field( 'tribe_events', 'event_venue', $args );
+		register_rest_field( 'tribe_events', 'start_date', $args );
+		register_rest_field( 'tribe_events', 'end_date', $args );
 	}
 }
 new WSU_Extended_Events_Calendar();


### PR DESCRIPTION
The REST API v2beta9 deprecates `register_api_field()`