### PR TITLE
[PR] Allow for showing a custom message and event details upon submission

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,16 +27,8 @@ matrix:
       env: WP_VERSION=latest WP_MULTISITE=1
 
 before_script:
-    - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
-    - |
-      if [[ "$WP_TRAVISCI" == "grunt" ]] ; then
-        npm install
-        composer install
-      fi
+    - npm install
+    - composer install
 
 script:
-    - phpunit
-    - |
-      if [[ "$WP_TRAVISCI" == "grunt" ]] ; then
-        grunt default
-      fi
+    - grunt

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,8 @@ branches:
 
 matrix:
   include:
-    - php: 5.6
-      env: WP_VERSION=latest WP_MULTISITE=0 WP_TRAVISCI=grunt
-    - php: 5.6
-      env: WP_VERSION=latest WP_MULTISITE=1
-    - php: 5.6
-      env: WP_VERSION=nightly WP_MULTISITE=1
     - php: 7.0
-      env: WP_VERSION=latest WP_MULTISITE=1
+      env: WP_VERSION=latest WP_MULTISITE=0 WP_TRAVISCI=grunt
 
 before_script:
     - npm install


### PR DESCRIPTION
When the 'Community Events' add-on is active, this extends the
settings on the 'Community' tab with options for allowing users
to display a custom message and details for events that have been
sucessfully submitted.